### PR TITLE
Fix invalid pubDate

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -11,7 +11,7 @@
 <title>{{ $post.Title }}</title>
 <link>{{ $post.URL }}</link>
 <guid>{{ $post.URL }}</guid>
-<pubDate>{{ $post.Date }}GMT</pubDate>
+<pubDate>{{ $post.Date }}</pubDate>
 <description>
 {{ $post.Body }}
 </description>


### PR DESCRIPTION
Template already adds  timezone. With GMT suffix, it generates invalid pubDate
`<pubDate>2025-02-17 00:00:00 +0000 UTCGMT</pubDate>`

My feedreader uses current time for all the entries. 